### PR TITLE
include a modern `use` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,13 @@ Add this to your `Cargo.toml`:
 [dependencies]
 structure = "0.1"
 ```
+Add this to your module:
 
-And this to your crate root:
+```rust
+use structure::{structure, structure_impl};
+```
+
+Or for pre-2018 versions of rust, add this to your crate root:
 
 ```rust
 #[macro_use]


### PR DESCRIPTION
note that using `use structure::structure` should be sufficient (see: [macro-changes](https://doc.rust-lang.org/edition-guide/rust-2018/macros/macro-changes.html)), but requires an update to the `proc-macro-hack` dependency (see: https://github.com/dtolnay/indoc/issues/24).