### PR TITLE
Add `no_std` support to structure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "structure"
+edition = "2018"
 version = "0.1.2"
 authors = ["Liran Ringel <liranringel@gmail.com>"]
 description = "Use format strings to create strongly-typed data pack/unpack interfaces."
@@ -17,8 +18,11 @@ travis-ci = { repository = "liranringel/structure" }
 appveyor = { repository = "liranringel/structure" }
 
 [dependencies]
-proc-macro-hack = "0.4"
 structure-macro-impl = { version = "0.1.2", path = "structure-macro-impl" }
-byteorder = "1"
+byteorder = { version = "1", default-features = false 
+
+[features]
+std = ["byteorder/std"]
+default = ["std"]
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ appveyor = { repository = "liranringel/structure" }
 
 [dependencies]
 structure-macro-impl = { version = "0.1.2", path = "structure-macro-impl" }
-byteorder = { version = "1", default-features = false 
+byteorder = { version = "1", default-features = false }
+core2 = { version = "0.3", default-features = false }
 
 [features]
 std = ["byteorder/std"]

--- a/src/byteorder_ext.rs
+++ b/src/byteorder_ext.rs
@@ -1,0 +1,1601 @@
+//! `no_std` compatible impl of `byteorder` 'ext' traits
+
+#[cfg(feature = "std")]
+use std::{
+    io::{self, Result},
+    slice,
+};
+
+#[cfg(not(feature = "std"))]
+use core2::io::{self, Result};
+
+#[cfg(not(feature = "std"))]
+use core::slice;
+
+use byteorder::ByteOrder;
+
+/// Extends [`Read`] with methods for reading numbers. (For `std::io`.)
+///
+/// Most of the methods defined here have an unconstrained type parameter that
+/// must be explicitly instantiated. Typically, it is instantiated with either
+/// the [`BigEndian`] or [`LittleEndian`] types defined in this crate.
+///
+/// # Examples
+///
+/// Read unsigned 16 bit big-endian integers from a [`Read`]:
+///
+/// ```rust
+/// use std::io::Cursor;
+/// use byteorder::{BigEndian, ReadBytesExt};
+///
+/// let mut rdr = Cursor::new(vec![2, 5, 3, 0]);
+/// assert_eq!(517, rdr.read_u16::<BigEndian>().unwrap());
+/// assert_eq!(768, rdr.read_u16::<BigEndian>().unwrap());
+/// ```
+///
+/// [`BigEndian`]: enum.BigEndian.html
+/// [`LittleEndian`]: enum.LittleEndian.html
+/// [`Read`]: https://doc.rust-lang.org/std/io/trait.Read.html
+pub trait ReadBytesExt: io::Read {
+    /// Reads an unsigned 8 bit integer from the underlying reader.
+    ///
+    /// Note that since this reads a single byte, no byte order conversions
+    /// are used. It is included for completeness.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read unsigned 8 bit integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::ReadBytesExt;
+    ///
+    /// let mut rdr = Cursor::new(vec![2, 5]);
+    /// assert_eq!(2, rdr.read_u8().unwrap());
+    /// assert_eq!(5, rdr.read_u8().unwrap());
+    /// ```
+    #[inline]
+    fn read_u8(&mut self) -> Result<u8> {
+        let mut buf = [0; 1];
+        self.read_exact(&mut buf)?;
+        Ok(buf[0])
+    }
+
+    /// Reads a signed 8 bit integer from the underlying reader.
+    ///
+    /// Note that since this reads a single byte, no byte order conversions
+    /// are used. It is included for completeness.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read signed 8 bit integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::ReadBytesExt;
+    ///
+    /// let mut rdr = Cursor::new(vec![0x02, 0xfb]);
+    /// assert_eq!(2, rdr.read_i8().unwrap());
+    /// assert_eq!(-5, rdr.read_i8().unwrap());
+    /// ```
+    #[inline]
+    fn read_i8(&mut self) -> Result<i8> {
+        let mut buf = [0; 1];
+        self.read_exact(&mut buf)?;
+        Ok(buf[0] as i8)
+    }
+
+    /// Reads an unsigned 16 bit integer from the underlying reader.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read unsigned 16 bit big-endian integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![2, 5, 3, 0]);
+    /// assert_eq!(517, rdr.read_u16::<BigEndian>().unwrap());
+    /// assert_eq!(768, rdr.read_u16::<BigEndian>().unwrap());
+    /// ```
+    #[inline]
+    fn read_u16<T: ByteOrder>(&mut self) -> Result<u16> {
+        let mut buf = [0; 2];
+        self.read_exact(&mut buf)?;
+        Ok(T::read_u16(&buf))
+    }
+
+    /// Reads a signed 16 bit integer from the underlying reader.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read signed 16 bit big-endian integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0x00, 0xc1, 0xff, 0x7c]);
+    /// assert_eq!(193, rdr.read_i16::<BigEndian>().unwrap());
+    /// assert_eq!(-132, rdr.read_i16::<BigEndian>().unwrap());
+    /// ```
+    #[inline]
+    fn read_i16<T: ByteOrder>(&mut self) -> Result<i16> {
+        let mut buf = [0; 2];
+        self.read_exact(&mut buf)?;
+        Ok(T::read_i16(&buf))
+    }
+
+    /// Reads an unsigned 24 bit integer from the underlying reader.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read unsigned 24 bit big-endian integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0x00, 0x01, 0x0b]);
+    /// assert_eq!(267, rdr.read_u24::<BigEndian>().unwrap());
+    /// ```
+    #[inline]
+    fn read_u24<T: ByteOrder>(&mut self) -> Result<u32> {
+        let mut buf = [0; 3];
+        self.read_exact(&mut buf)?;
+        Ok(T::read_u24(&buf))
+    }
+
+    /// Reads a signed 24 bit integer from the underlying reader.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read signed 24 bit big-endian integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0xff, 0x7a, 0x33]);
+    /// assert_eq!(-34253, rdr.read_i24::<BigEndian>().unwrap());
+    /// ```
+    #[inline]
+    fn read_i24<T: ByteOrder>(&mut self) -> Result<i32> {
+        let mut buf = [0; 3];
+        self.read_exact(&mut buf)?;
+        Ok(T::read_i24(&buf))
+    }
+
+    /// Reads an unsigned 32 bit integer from the underlying reader.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read unsigned 32 bit big-endian integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0x00, 0x00, 0x01, 0x0b]);
+    /// assert_eq!(267, rdr.read_u32::<BigEndian>().unwrap());
+    /// ```
+    #[inline]
+    fn read_u32<T: ByteOrder>(&mut self) -> Result<u32> {
+        let mut buf = [0; 4];
+        self.read_exact(&mut buf)?;
+        Ok(T::read_u32(&buf))
+    }
+
+    /// Reads a signed 32 bit integer from the underlying reader.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read signed 32 bit big-endian integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0xff, 0xff, 0x7a, 0x33]);
+    /// assert_eq!(-34253, rdr.read_i32::<BigEndian>().unwrap());
+    /// ```
+    #[inline]
+    fn read_i32<T: ByteOrder>(&mut self) -> Result<i32> {
+        let mut buf = [0; 4];
+        self.read_exact(&mut buf)?;
+        Ok(T::read_i32(&buf))
+    }
+
+    /// Reads an unsigned 48 bit integer from the underlying reader.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read unsigned 48 bit big-endian integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0xb6, 0x71, 0x6b, 0xdc, 0x2b, 0x31]);
+    /// assert_eq!(200598257150769, rdr.read_u48::<BigEndian>().unwrap());
+    /// ```
+    #[inline]
+    fn read_u48<T: ByteOrder>(&mut self) -> Result<u64> {
+        let mut buf = [0; 6];
+        self.read_exact(&mut buf)?;
+        Ok(T::read_u48(&buf))
+    }
+
+    /// Reads a signed 48 bit integer from the underlying reader.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read signed 48 bit big-endian integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0x9d, 0x71, 0xab, 0xe7, 0x97, 0x8f]);
+    /// assert_eq!(-108363435763825, rdr.read_i48::<BigEndian>().unwrap());
+    /// ```
+    #[inline]
+    fn read_i48<T: ByteOrder>(&mut self) -> Result<i64> {
+        let mut buf = [0; 6];
+        self.read_exact(&mut buf)?;
+        Ok(T::read_i48(&buf))
+    }
+
+    /// Reads an unsigned 64 bit integer from the underlying reader.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read an unsigned 64 bit big-endian integer from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0x00, 0x03, 0x43, 0x95, 0x4d, 0x60, 0x86, 0x83]);
+    /// assert_eq!(918733457491587, rdr.read_u64::<BigEndian>().unwrap());
+    /// ```
+    #[inline]
+    fn read_u64<T: ByteOrder>(&mut self) -> Result<u64> {
+        let mut buf = [0; 8];
+        self.read_exact(&mut buf)?;
+        Ok(T::read_u64(&buf))
+    }
+
+    /// Reads a signed 64 bit integer from the underlying reader.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a signed 64 bit big-endian integer from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0x80, 0, 0, 0, 0, 0, 0, 0]);
+    /// assert_eq!(i64::min_value(), rdr.read_i64::<BigEndian>().unwrap());
+    /// ```
+    #[inline]
+    fn read_i64<T: ByteOrder>(&mut self) -> Result<i64> {
+        let mut buf = [0; 8];
+        self.read_exact(&mut buf)?;
+        Ok(T::read_i64(&buf))
+    }
+
+    /// Reads an unsigned 128 bit integer from the underlying reader.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read an unsigned 128 bit big-endian integer from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![
+    ///     0x00, 0x03, 0x43, 0x95, 0x4d, 0x60, 0x86, 0x83,
+    ///     0x00, 0x03, 0x43, 0x95, 0x4d, 0x60, 0x86, 0x83
+    /// ]);
+    /// assert_eq!(16947640962301618749969007319746179, rdr.read_u128::<BigEndian>().unwrap());
+    /// ```
+    #[inline]
+    fn read_u128<T: ByteOrder>(&mut self) -> Result<u128> {
+        let mut buf = [0; 16];
+        self.read_exact(&mut buf)?;
+        Ok(T::read_u128(&buf))
+    }
+
+    /// Reads a signed 128 bit integer from the underlying reader.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a signed 128 bit big-endian integer from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    /// assert_eq!(i128::min_value(), rdr.read_i128::<BigEndian>().unwrap());
+    /// ```
+    #[inline]
+    fn read_i128<T: ByteOrder>(&mut self) -> Result<i128> {
+        let mut buf = [0; 16];
+        self.read_exact(&mut buf)?;
+        Ok(T::read_i128(&buf))
+    }
+
+    /// Reads an unsigned n-bytes integer from the underlying reader.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read an unsigned n-byte big-endian integer from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0x80, 0x74, 0xfa]);
+    /// assert_eq!(8418554, rdr.read_uint::<BigEndian>(3).unwrap());
+    #[inline]
+    fn read_uint<T: ByteOrder>(&mut self, nbytes: usize) -> Result<u64> {
+        let mut buf = [0; 8];
+        self.read_exact(&mut buf[..nbytes])?;
+        Ok(T::read_uint(&buf[..nbytes], nbytes))
+    }
+
+    /// Reads a signed n-bytes integer from the underlying reader.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read an unsigned n-byte big-endian integer from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0xc1, 0xff, 0x7c]);
+    /// assert_eq!(-4063364, rdr.read_int::<BigEndian>(3).unwrap());
+    #[inline]
+    fn read_int<T: ByteOrder>(&mut self, nbytes: usize) -> Result<i64> {
+        let mut buf = [0; 8];
+        self.read_exact(&mut buf[..nbytes])?;
+        Ok(T::read_int(&buf[..nbytes], nbytes))
+    }
+
+    /// Reads an unsigned n-bytes integer from the underlying reader.
+    #[inline]
+    fn read_uint128<T: ByteOrder>(&mut self, nbytes: usize) -> Result<u128> {
+        let mut buf = [0; 16];
+        self.read_exact(&mut buf[..nbytes])?;
+        Ok(T::read_uint128(&buf[..nbytes], nbytes))
+    }
+
+    /// Reads a signed n-bytes integer from the underlying reader.
+    #[inline]
+    fn read_int128<T: ByteOrder>(&mut self, nbytes: usize) -> Result<i128> {
+        let mut buf = [0; 16];
+        self.read_exact(&mut buf[..nbytes])?;
+        Ok(T::read_int128(&buf[..nbytes], nbytes))
+    }
+
+    /// Reads a IEEE754 single-precision (4 bytes) floating point number from
+    /// the underlying reader.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a big-endian single-precision floating point number from a `Read`:
+    ///
+    /// ```rust
+    /// use std::f32;
+    /// use std::io::Cursor;
+    ///
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![
+    ///     0x40, 0x49, 0x0f, 0xdb,
+    /// ]);
+    /// assert_eq!(f32::consts::PI, rdr.read_f32::<BigEndian>().unwrap());
+    /// ```
+    #[inline]
+    fn read_f32<T: ByteOrder>(&mut self) -> Result<f32> {
+        let mut buf = [0; 4];
+        self.read_exact(&mut buf)?;
+        Ok(T::read_f32(&buf))
+    }
+
+    /// Reads a IEEE754 double-precision (8 bytes) floating point number from
+    /// the underlying reader.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a big-endian double-precision floating point number from a `Read`:
+    ///
+    /// ```rust
+    /// use std::f64;
+    /// use std::io::Cursor;
+    ///
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![
+    ///     0x40, 0x09, 0x21, 0xfb, 0x54, 0x44, 0x2d, 0x18,
+    /// ]);
+    /// assert_eq!(f64::consts::PI, rdr.read_f64::<BigEndian>().unwrap());
+    /// ```
+    #[inline]
+    fn read_f64<T: ByteOrder>(&mut self) -> Result<f64> {
+        let mut buf = [0; 8];
+        self.read_exact(&mut buf)?;
+        Ok(T::read_f64(&buf))
+    }
+
+    /// Reads a sequence of unsigned 16 bit integers from the underlying
+    /// reader.
+    ///
+    /// The given buffer is either filled completely or an error is returned.
+    /// If an error is returned, the contents of `dst` are unspecified.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a sequence of unsigned 16 bit big-endian integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![2, 5, 3, 0]);
+    /// let mut dst = [0; 2];
+    /// rdr.read_u16_into::<BigEndian>(&mut dst).unwrap();
+    /// assert_eq!([517, 768], dst);
+    /// ```
+    #[inline]
+    fn read_u16_into<T: ByteOrder>(&mut self, dst: &mut [u16]) -> Result<()> {
+        {
+            let buf = unsafe { slice_to_u8_mut(dst) };
+            self.read_exact(buf)?;
+        }
+        T::from_slice_u16(dst);
+        Ok(())
+    }
+
+    /// Reads a sequence of unsigned 32 bit integers from the underlying
+    /// reader.
+    ///
+    /// The given buffer is either filled completely or an error is returned.
+    /// If an error is returned, the contents of `dst` are unspecified.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a sequence of unsigned 32 bit big-endian integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0, 0, 2, 5, 0, 0, 3, 0]);
+    /// let mut dst = [0; 2];
+    /// rdr.read_u32_into::<BigEndian>(&mut dst).unwrap();
+    /// assert_eq!([517, 768], dst);
+    /// ```
+    #[inline]
+    fn read_u32_into<T: ByteOrder>(&mut self, dst: &mut [u32]) -> Result<()> {
+        {
+            let buf = unsafe { slice_to_u8_mut(dst) };
+            self.read_exact(buf)?;
+        }
+        T::from_slice_u32(dst);
+        Ok(())
+    }
+
+    /// Reads a sequence of unsigned 64 bit integers from the underlying
+    /// reader.
+    ///
+    /// The given buffer is either filled completely or an error is returned.
+    /// If an error is returned, the contents of `dst` are unspecified.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a sequence of unsigned 64 bit big-endian integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![
+    ///     0, 0, 0, 0, 0, 0, 2, 5,
+    ///     0, 0, 0, 0, 0, 0, 3, 0,
+    /// ]);
+    /// let mut dst = [0; 2];
+    /// rdr.read_u64_into::<BigEndian>(&mut dst).unwrap();
+    /// assert_eq!([517, 768], dst);
+    /// ```
+    #[inline]
+    fn read_u64_into<T: ByteOrder>(&mut self, dst: &mut [u64]) -> Result<()> {
+        {
+            let buf = unsafe { slice_to_u8_mut(dst) };
+            self.read_exact(buf)?;
+        }
+        T::from_slice_u64(dst);
+        Ok(())
+    }
+
+    /// Reads a sequence of unsigned 128 bit integers from the underlying
+    /// reader.
+    ///
+    /// The given buffer is either filled completely or an error is returned.
+    /// If an error is returned, the contents of `dst` are unspecified.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a sequence of unsigned 128 bit big-endian integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![
+    ///     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 5,
+    ///     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0,
+    /// ]);
+    /// let mut dst = [0; 2];
+    /// rdr.read_u128_into::<BigEndian>(&mut dst).unwrap();
+    /// assert_eq!([517, 768], dst);
+    /// ```
+    #[inline]
+    fn read_u128_into<T: ByteOrder>(
+        &mut self,
+        dst: &mut [u128],
+    ) -> Result<()> {
+        {
+            let buf = unsafe { slice_to_u8_mut(dst) };
+            self.read_exact(buf)?;
+        }
+        T::from_slice_u128(dst);
+        Ok(())
+    }
+
+    /// Reads a sequence of signed 8 bit integers from the underlying reader.
+    ///
+    /// The given buffer is either filled completely or an error is returned.
+    /// If an error is returned, the contents of `dst` are unspecified.
+    ///
+    /// Note that since each `i8` is a single byte, no byte order conversions
+    /// are used. This method is included because it provides a safe, simple
+    /// way for the caller to read into a `&mut [i8]` buffer. (Without this
+    /// method, the caller would have to either use `unsafe` code or convert
+    /// each byte to `i8` individually.)
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a sequence of signed 8 bit integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![2, 251, 3]);
+    /// let mut dst = [0; 3];
+    /// rdr.read_i8_into(&mut dst).unwrap();
+    /// assert_eq!([2, -5, 3], dst);
+    /// ```
+    #[inline]
+    fn read_i8_into(&mut self, dst: &mut [i8]) -> Result<()> {
+        let buf = unsafe { slice_to_u8_mut(dst) };
+        self.read_exact(buf)
+    }
+
+    /// Reads a sequence of signed 16 bit integers from the underlying
+    /// reader.
+    ///
+    /// The given buffer is either filled completely or an error is returned.
+    /// If an error is returned, the contents of `dst` are unspecified.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a sequence of signed 16 bit big-endian integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![2, 5, 3, 0]);
+    /// let mut dst = [0; 2];
+    /// rdr.read_i16_into::<BigEndian>(&mut dst).unwrap();
+    /// assert_eq!([517, 768], dst);
+    /// ```
+    #[inline]
+    fn read_i16_into<T: ByteOrder>(&mut self, dst: &mut [i16]) -> Result<()> {
+        {
+            let buf = unsafe { slice_to_u8_mut(dst) };
+            self.read_exact(buf)?;
+        }
+        T::from_slice_i16(dst);
+        Ok(())
+    }
+
+    /// Reads a sequence of signed 32 bit integers from the underlying
+    /// reader.
+    ///
+    /// The given buffer is either filled completely or an error is returned.
+    /// If an error is returned, the contents of `dst` are unspecified.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a sequence of signed 32 bit big-endian integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0, 0, 2, 5, 0, 0, 3, 0]);
+    /// let mut dst = [0; 2];
+    /// rdr.read_i32_into::<BigEndian>(&mut dst).unwrap();
+    /// assert_eq!([517, 768], dst);
+    /// ```
+    #[inline]
+    fn read_i32_into<T: ByteOrder>(&mut self, dst: &mut [i32]) -> Result<()> {
+        {
+            let buf = unsafe { slice_to_u8_mut(dst) };
+            self.read_exact(buf)?;
+        }
+        T::from_slice_i32(dst);
+        Ok(())
+    }
+
+    /// Reads a sequence of signed 64 bit integers from the underlying
+    /// reader.
+    ///
+    /// The given buffer is either filled completely or an error is returned.
+    /// If an error is returned, the contents of `dst` are unspecified.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a sequence of signed 64 bit big-endian integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![
+    ///     0, 0, 0, 0, 0, 0, 2, 5,
+    ///     0, 0, 0, 0, 0, 0, 3, 0,
+    /// ]);
+    /// let mut dst = [0; 2];
+    /// rdr.read_i64_into::<BigEndian>(&mut dst).unwrap();
+    /// assert_eq!([517, 768], dst);
+    /// ```
+    #[inline]
+    fn read_i64_into<T: ByteOrder>(&mut self, dst: &mut [i64]) -> Result<()> {
+        {
+            let buf = unsafe { slice_to_u8_mut(dst) };
+            self.read_exact(buf)?;
+        }
+        T::from_slice_i64(dst);
+        Ok(())
+    }
+
+    /// Reads a sequence of signed 128 bit integers from the underlying
+    /// reader.
+    ///
+    /// The given buffer is either filled completely or an error is returned.
+    /// If an error is returned, the contents of `dst` are unspecified.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a sequence of signed 128 bit big-endian integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![
+    ///     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 5,
+    ///     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0,
+    /// ]);
+    /// let mut dst = [0; 2];
+    /// rdr.read_i128_into::<BigEndian>(&mut dst).unwrap();
+    /// assert_eq!([517, 768], dst);
+    /// ```
+    #[inline]
+    fn read_i128_into<T: ByteOrder>(
+        &mut self,
+        dst: &mut [i128],
+    ) -> Result<()> {
+        {
+            let buf = unsafe { slice_to_u8_mut(dst) };
+            self.read_exact(buf)?;
+        }
+        T::from_slice_i128(dst);
+        Ok(())
+    }
+
+    /// Reads a sequence of IEEE754 single-precision (4 bytes) floating
+    /// point numbers from the underlying reader.
+    ///
+    /// The given buffer is either filled completely or an error is returned.
+    /// If an error is returned, the contents of `dst` are unspecified.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a sequence of big-endian single-precision floating point number
+    /// from a `Read`:
+    ///
+    /// ```rust
+    /// use std::f32;
+    /// use std::io::Cursor;
+    ///
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![
+    ///     0x40, 0x49, 0x0f, 0xdb,
+    ///     0x3f, 0x80, 0x00, 0x00,
+    /// ]);
+    /// let mut dst = [0.0; 2];
+    /// rdr.read_f32_into::<BigEndian>(&mut dst).unwrap();
+    /// assert_eq!([f32::consts::PI, 1.0], dst);
+    /// ```
+    #[inline]
+    fn read_f32_into<T: ByteOrder>(&mut self, dst: &mut [f32]) -> Result<()> {
+        {
+            let buf = unsafe { slice_to_u8_mut(dst) };
+            self.read_exact(buf)?;
+        }
+        T::from_slice_f32(dst);
+        Ok(())
+    }
+
+    /// **DEPRECATED**.
+    ///
+    /// This method is deprecated. Use `read_f32_into` instead.
+    ///
+    /// Reads a sequence of IEEE754 single-precision (4 bytes) floating
+    /// point numbers from the underlying reader.
+    ///
+    /// The given buffer is either filled completely or an error is returned.
+    /// If an error is returned, the contents of `dst` are unspecified.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a sequence of big-endian single-precision floating point number
+    /// from a `Read`:
+    ///
+    /// ```rust
+    /// use std::f32;
+    /// use std::io::Cursor;
+    ///
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![
+    ///     0x40, 0x49, 0x0f, 0xdb,
+    ///     0x3f, 0x80, 0x00, 0x00,
+    /// ]);
+    /// let mut dst = [0.0; 2];
+    /// rdr.read_f32_into_unchecked::<BigEndian>(&mut dst).unwrap();
+    /// assert_eq!([f32::consts::PI, 1.0], dst);
+    /// ```
+    #[inline]
+    #[deprecated(since = "1.2.0", note = "please use `read_f32_into` instead")]
+    fn read_f32_into_unchecked<T: ByteOrder>(
+        &mut self,
+        dst: &mut [f32],
+    ) -> Result<()> {
+        self.read_f32_into::<T>(dst)
+    }
+
+    /// Reads a sequence of IEEE754 double-precision (8 bytes) floating
+    /// point numbers from the underlying reader.
+    ///
+    /// The given buffer is either filled completely or an error is returned.
+    /// If an error is returned, the contents of `dst` are unspecified.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a sequence of big-endian single-precision floating point number
+    /// from a `Read`:
+    ///
+    /// ```rust
+    /// use std::f64;
+    /// use std::io::Cursor;
+    ///
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![
+    ///     0x40, 0x09, 0x21, 0xfb, 0x54, 0x44, 0x2d, 0x18,
+    ///     0x3f, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    /// ]);
+    /// let mut dst = [0.0; 2];
+    /// rdr.read_f64_into::<BigEndian>(&mut dst).unwrap();
+    /// assert_eq!([f64::consts::PI, 1.0], dst);
+    /// ```
+    #[inline]
+    fn read_f64_into<T: ByteOrder>(&mut self, dst: &mut [f64]) -> Result<()> {
+        {
+            let buf = unsafe { slice_to_u8_mut(dst) };
+            self.read_exact(buf)?;
+        }
+        T::from_slice_f64(dst);
+        Ok(())
+    }
+
+    /// **DEPRECATED**.
+    ///
+    /// This method is deprecated. Use `read_f64_into` instead.
+    ///
+    /// Reads a sequence of IEEE754 double-precision (8 bytes) floating
+    /// point numbers from the underlying reader.
+    ///
+    /// The given buffer is either filled completely or an error is returned.
+    /// If an error is returned, the contents of `dst` are unspecified.
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe because there are no guarantees made about the
+    /// floating point values. In particular, this method does not check for
+    /// signaling NaNs, which may result in undefined behavior.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a sequence of big-endian single-precision floating point number
+    /// from a `Read`:
+    ///
+    /// ```rust
+    /// use std::f64;
+    /// use std::io::Cursor;
+    ///
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![
+    ///     0x40, 0x09, 0x21, 0xfb, 0x54, 0x44, 0x2d, 0x18,
+    ///     0x3f, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    /// ]);
+    /// let mut dst = [0.0; 2];
+    /// rdr.read_f64_into_unchecked::<BigEndian>(&mut dst).unwrap();
+    /// assert_eq!([f64::consts::PI, 1.0], dst);
+    /// ```
+    #[inline]
+    #[deprecated(since = "1.2.0", note = "please use `read_f64_into` instead")]
+    fn read_f64_into_unchecked<T: ByteOrder>(
+        &mut self,
+        dst: &mut [f64],
+    ) -> Result<()> {
+        self.read_f64_into::<T>(dst)
+    }
+}
+
+/// All types that implement `Read` get methods defined in `ReadBytesExt`
+/// for free.
+impl<R: io::Read + ?Sized> ReadBytesExt for R {}
+
+/// Extends [`Write`] with methods for writing numbers. (For `std::io`.)
+///
+/// Most of the methods defined here have an unconstrained type parameter that
+/// must be explicitly instantiated. Typically, it is instantiated with either
+/// the [`BigEndian`] or [`LittleEndian`] types defined in this crate.
+///
+/// # Examples
+///
+/// Write unsigned 16 bit big-endian integers to a [`Write`]:
+///
+/// ```rust
+/// use byteorder::{BigEndian, WriteBytesExt};
+///
+/// let mut wtr = vec![];
+/// wtr.write_u16::<BigEndian>(517).unwrap();
+/// wtr.write_u16::<BigEndian>(768).unwrap();
+/// assert_eq!(wtr, vec![2, 5, 3, 0]);
+/// ```
+///
+/// [`BigEndian`]: enum.BigEndian.html
+/// [`LittleEndian`]: enum.LittleEndian.html
+/// [`Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
+pub trait WriteBytesExt: io::Write {
+    /// Writes an unsigned 8 bit integer to the underlying writer.
+    ///
+    /// Note that since this writes a single byte, no byte order conversions
+    /// are used. It is included for completeness.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Write::write_all`].
+    ///
+    /// [`Write::write_all`]: https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all
+    ///
+    /// # Examples
+    ///
+    /// Write unsigned 8 bit integers to a `Write`:
+    ///
+    /// ```rust
+    /// use byteorder::WriteBytesExt;
+    ///
+    /// let mut wtr = Vec::new();
+    /// wtr.write_u8(2).unwrap();
+    /// wtr.write_u8(5).unwrap();
+    /// assert_eq!(wtr, b"\x02\x05");
+    /// ```
+    #[inline]
+    fn write_u8(&mut self, n: u8) -> Result<()> {
+        self.write_all(&[n])
+    }
+
+    /// Writes a signed 8 bit integer to the underlying writer.
+    ///
+    /// Note that since this writes a single byte, no byte order conversions
+    /// are used. It is included for completeness.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Write::write_all`].
+    ///
+    /// [`Write::write_all`]: https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all
+    ///
+    /// # Examples
+    ///
+    /// Write signed 8 bit integers to a `Write`:
+    ///
+    /// ```rust
+    /// use byteorder::WriteBytesExt;
+    ///
+    /// let mut wtr = Vec::new();
+    /// wtr.write_i8(2).unwrap();
+    /// wtr.write_i8(-5).unwrap();
+    /// assert_eq!(wtr, b"\x02\xfb");
+    /// ```
+    #[inline]
+    fn write_i8(&mut self, n: i8) -> Result<()> {
+        self.write_all(&[n as u8])
+    }
+
+    /// Writes an unsigned 16 bit integer to the underlying writer.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Write::write_all`].
+    ///
+    /// [`Write::write_all`]: https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all
+    ///
+    /// # Examples
+    ///
+    /// Write unsigned 16 bit big-endian integers to a `Write`:
+    ///
+    /// ```rust
+    /// use byteorder::{BigEndian, WriteBytesExt};
+    ///
+    /// let mut wtr = Vec::new();
+    /// wtr.write_u16::<BigEndian>(517).unwrap();
+    /// wtr.write_u16::<BigEndian>(768).unwrap();
+    /// assert_eq!(wtr, b"\x02\x05\x03\x00");
+    /// ```
+    #[inline]
+    fn write_u16<T: ByteOrder>(&mut self, n: u16) -> Result<()> {
+        let mut buf = [0; 2];
+        T::write_u16(&mut buf, n);
+        self.write_all(&buf)
+    }
+
+    /// Writes a signed 16 bit integer to the underlying writer.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Write::write_all`].
+    ///
+    /// [`Write::write_all`]: https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all
+    ///
+    /// # Examples
+    ///
+    /// Write signed 16 bit big-endian integers to a `Write`:
+    ///
+    /// ```rust
+    /// use byteorder::{BigEndian, WriteBytesExt};
+    ///
+    /// let mut wtr = Vec::new();
+    /// wtr.write_i16::<BigEndian>(193).unwrap();
+    /// wtr.write_i16::<BigEndian>(-132).unwrap();
+    /// assert_eq!(wtr, b"\x00\xc1\xff\x7c");
+    /// ```
+    #[inline]
+    fn write_i16<T: ByteOrder>(&mut self, n: i16) -> Result<()> {
+        let mut buf = [0; 2];
+        T::write_i16(&mut buf, n);
+        self.write_all(&buf)
+    }
+
+    /// Writes an unsigned 24 bit integer to the underlying writer.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Write::write_all`].
+    ///
+    /// [`Write::write_all`]: https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all
+    ///
+    /// # Examples
+    ///
+    /// Write unsigned 24 bit big-endian integers to a `Write`:
+    ///
+    /// ```rust
+    /// use byteorder::{BigEndian, WriteBytesExt};
+    ///
+    /// let mut wtr = Vec::new();
+    /// wtr.write_u24::<BigEndian>(267).unwrap();
+    /// wtr.write_u24::<BigEndian>(120111).unwrap();
+    /// assert_eq!(wtr, b"\x00\x01\x0b\x01\xd5\x2f");
+    /// ```
+    #[inline]
+    fn write_u24<T: ByteOrder>(&mut self, n: u32) -> Result<()> {
+        let mut buf = [0; 3];
+        T::write_u24(&mut buf, n);
+        self.write_all(&buf)
+    }
+
+    /// Writes a signed 24 bit integer to the underlying writer.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Write::write_all`].
+    ///
+    /// [`Write::write_all`]: https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all
+    ///
+    /// # Examples
+    ///
+    /// Write signed 24 bit big-endian integers to a `Write`:
+    ///
+    /// ```rust
+    /// use byteorder::{BigEndian, WriteBytesExt};
+    ///
+    /// let mut wtr = Vec::new();
+    /// wtr.write_i24::<BigEndian>(-34253).unwrap();
+    /// wtr.write_i24::<BigEndian>(120111).unwrap();
+    /// assert_eq!(wtr, b"\xff\x7a\x33\x01\xd5\x2f");
+    /// ```
+    #[inline]
+    fn write_i24<T: ByteOrder>(&mut self, n: i32) -> Result<()> {
+        let mut buf = [0; 3];
+        T::write_i24(&mut buf, n);
+        self.write_all(&buf)
+    }
+
+    /// Writes an unsigned 32 bit integer to the underlying writer.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Write::write_all`].
+    ///
+    /// [`Write::write_all`]: https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all
+    ///
+    /// # Examples
+    ///
+    /// Write unsigned 32 bit big-endian integers to a `Write`:
+    ///
+    /// ```rust
+    /// use byteorder::{BigEndian, WriteBytesExt};
+    ///
+    /// let mut wtr = Vec::new();
+    /// wtr.write_u32::<BigEndian>(267).unwrap();
+    /// wtr.write_u32::<BigEndian>(1205419366).unwrap();
+    /// assert_eq!(wtr, b"\x00\x00\x01\x0b\x47\xd9\x3d\x66");
+    /// ```
+    #[inline]
+    fn write_u32<T: ByteOrder>(&mut self, n: u32) -> Result<()> {
+        let mut buf = [0; 4];
+        T::write_u32(&mut buf, n);
+        self.write_all(&buf)
+    }
+
+    /// Writes a signed 32 bit integer to the underlying writer.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Write::write_all`].
+    ///
+    /// [`Write::write_all`]: https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all
+    ///
+    /// # Examples
+    ///
+    /// Write signed 32 bit big-endian integers to a `Write`:
+    ///
+    /// ```rust
+    /// use byteorder::{BigEndian, WriteBytesExt};
+    ///
+    /// let mut wtr = Vec::new();
+    /// wtr.write_i32::<BigEndian>(-34253).unwrap();
+    /// wtr.write_i32::<BigEndian>(1205419366).unwrap();
+    /// assert_eq!(wtr, b"\xff\xff\x7a\x33\x47\xd9\x3d\x66");
+    /// ```
+    #[inline]
+    fn write_i32<T: ByteOrder>(&mut self, n: i32) -> Result<()> {
+        let mut buf = [0; 4];
+        T::write_i32(&mut buf, n);
+        self.write_all(&buf)
+    }
+
+    /// Writes an unsigned 48 bit integer to the underlying writer.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Write::write_all`].
+    ///
+    /// [`Write::write_all`]: https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all
+    ///
+    /// # Examples
+    ///
+    /// Write unsigned 48 bit big-endian integers to a `Write`:
+    ///
+    /// ```rust
+    /// use byteorder::{BigEndian, WriteBytesExt};
+    ///
+    /// let mut wtr = Vec::new();
+    /// wtr.write_u48::<BigEndian>(52360336390828).unwrap();
+    /// wtr.write_u48::<BigEndian>(541).unwrap();
+    /// assert_eq!(wtr, b"\x2f\x9f\x17\x40\x3a\xac\x00\x00\x00\x00\x02\x1d");
+    /// ```
+    #[inline]
+    fn write_u48<T: ByteOrder>(&mut self, n: u64) -> Result<()> {
+        let mut buf = [0; 6];
+        T::write_u48(&mut buf, n);
+        self.write_all(&buf)
+    }
+
+    /// Writes a signed 48 bit integer to the underlying writer.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Write::write_all`].
+    ///
+    /// [`Write::write_all`]: https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all
+    ///
+    /// # Examples
+    ///
+    /// Write signed 48 bit big-endian integers to a `Write`:
+    ///
+    /// ```rust
+    /// use byteorder::{BigEndian, WriteBytesExt};
+    ///
+    /// let mut wtr = Vec::new();
+    /// wtr.write_i48::<BigEndian>(-108363435763825).unwrap();
+    /// wtr.write_i48::<BigEndian>(77).unwrap();
+    /// assert_eq!(wtr, b"\x9d\x71\xab\xe7\x97\x8f\x00\x00\x00\x00\x00\x4d");
+    /// ```
+    #[inline]
+    fn write_i48<T: ByteOrder>(&mut self, n: i64) -> Result<()> {
+        let mut buf = [0; 6];
+        T::write_i48(&mut buf, n);
+        self.write_all(&buf)
+    }
+
+    /// Writes an unsigned 64 bit integer to the underlying writer.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Write::write_all`].
+    ///
+    /// [`Write::write_all`]: https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all
+    ///
+    /// # Examples
+    ///
+    /// Write unsigned 64 bit big-endian integers to a `Write`:
+    ///
+    /// ```rust
+    /// use byteorder::{BigEndian, WriteBytesExt};
+    ///
+    /// let mut wtr = Vec::new();
+    /// wtr.write_u64::<BigEndian>(918733457491587).unwrap();
+    /// wtr.write_u64::<BigEndian>(143).unwrap();
+    /// assert_eq!(wtr, b"\x00\x03\x43\x95\x4d\x60\x86\x83\x00\x00\x00\x00\x00\x00\x00\x8f");
+    /// ```
+    #[inline]
+    fn write_u64<T: ByteOrder>(&mut self, n: u64) -> Result<()> {
+        let mut buf = [0; 8];
+        T::write_u64(&mut buf, n);
+        self.write_all(&buf)
+    }
+
+    /// Writes a signed 64 bit integer to the underlying writer.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Write::write_all`].
+    ///
+    /// [`Write::write_all`]: https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all
+    ///
+    /// # Examples
+    ///
+    /// Write signed 64 bit big-endian integers to a `Write`:
+    ///
+    /// ```rust
+    /// use byteorder::{BigEndian, WriteBytesExt};
+    ///
+    /// let mut wtr = Vec::new();
+    /// wtr.write_i64::<BigEndian>(i64::min_value()).unwrap();
+    /// wtr.write_i64::<BigEndian>(i64::max_value()).unwrap();
+    /// assert_eq!(wtr, b"\x80\x00\x00\x00\x00\x00\x00\x00\x7f\xff\xff\xff\xff\xff\xff\xff");
+    /// ```
+    #[inline]
+    fn write_i64<T: ByteOrder>(&mut self, n: i64) -> Result<()> {
+        let mut buf = [0; 8];
+        T::write_i64(&mut buf, n);
+        self.write_all(&buf)
+    }
+
+    /// Writes an unsigned 128 bit integer to the underlying writer.
+    #[inline]
+    fn write_u128<T: ByteOrder>(&mut self, n: u128) -> Result<()> {
+        let mut buf = [0; 16];
+        T::write_u128(&mut buf, n);
+        self.write_all(&buf)
+    }
+
+    /// Writes a signed 128 bit integer to the underlying writer.
+    #[inline]
+    fn write_i128<T: ByteOrder>(&mut self, n: i128) -> Result<()> {
+        let mut buf = [0; 16];
+        T::write_i128(&mut buf, n);
+        self.write_all(&buf)
+    }
+
+    /// Writes an unsigned n-bytes integer to the underlying writer.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Write::write_all`].
+    ///
+    /// [`Write::write_all`]: https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all
+    ///
+    /// # Panics
+    ///
+    /// If the given integer is not representable in the given number of bytes,
+    /// this method panics. If `nbytes > 8`, this method panics.
+    ///
+    /// # Examples
+    ///
+    /// Write unsigned 40 bit big-endian integers to a `Write`:
+    ///
+    /// ```rust
+    /// use byteorder::{BigEndian, WriteBytesExt};
+    ///
+    /// let mut wtr = Vec::new();
+    /// wtr.write_uint::<BigEndian>(312550384361, 5).unwrap();
+    /// wtr.write_uint::<BigEndian>(43, 5).unwrap();
+    /// assert_eq!(wtr, b"\x48\xc5\x74\x62\xe9\x00\x00\x00\x00\x2b");
+    /// ```
+    #[inline]
+    fn write_uint<T: ByteOrder>(
+        &mut self,
+        n: u64,
+        nbytes: usize,
+    ) -> Result<()> {
+        let mut buf = [0; 8];
+        T::write_uint(&mut buf, n, nbytes);
+        self.write_all(&buf[0..nbytes])
+    }
+
+    /// Writes a signed n-bytes integer to the underlying writer.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Write::write_all`].
+    ///
+    /// [`Write::write_all`]: https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all
+    ///
+    /// # Panics
+    ///
+    /// If the given integer is not representable in the given number of bytes,
+    /// this method panics. If `nbytes > 8`, this method panics.
+    ///
+    /// # Examples
+    ///
+    /// Write signed 56 bit big-endian integers to a `Write`:
+    ///
+    /// ```rust
+    /// use byteorder::{BigEndian, WriteBytesExt};
+    ///
+    /// let mut wtr = Vec::new();
+    /// wtr.write_int::<BigEndian>(-3548172039376767, 7).unwrap();
+    /// wtr.write_int::<BigEndian>(43, 7).unwrap();
+    /// assert_eq!(wtr, b"\xf3\x64\xf4\xd1\xfd\xb0\x81\x00\x00\x00\x00\x00\x00\x2b");
+    /// ```
+    #[inline]
+    fn write_int<T: ByteOrder>(
+        &mut self,
+        n: i64,
+        nbytes: usize,
+    ) -> Result<()> {
+        let mut buf = [0; 8];
+        T::write_int(&mut buf, n, nbytes);
+        self.write_all(&buf[0..nbytes])
+    }
+
+    /// Writes an unsigned n-bytes integer to the underlying writer.
+    ///
+    /// If the given integer is not representable in the given number of bytes,
+    /// this method panics. If `nbytes > 16`, this method panics.
+    #[inline]
+    fn write_uint128<T: ByteOrder>(
+        &mut self,
+        n: u128,
+        nbytes: usize,
+    ) -> Result<()> {
+        let mut buf = [0; 16];
+        T::write_uint128(&mut buf, n, nbytes);
+        self.write_all(&buf[0..nbytes])
+    }
+
+    /// Writes a signed n-bytes integer to the underlying writer.
+    ///
+    /// If the given integer is not representable in the given number of bytes,
+    /// this method panics. If `nbytes > 16`, this method panics.
+    #[inline]
+    fn write_int128<T: ByteOrder>(
+        &mut self,
+        n: i128,
+        nbytes: usize,
+    ) -> Result<()> {
+        let mut buf = [0; 16];
+        T::write_int128(&mut buf, n, nbytes);
+        self.write_all(&buf[0..nbytes])
+    }
+
+    /// Writes a IEEE754 single-precision (4 bytes) floating point number to
+    /// the underlying writer.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Write::write_all`].
+    ///
+    /// [`Write::write_all`]: https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all
+    ///
+    /// # Examples
+    ///
+    /// Write a big-endian single-precision floating point number to a `Write`:
+    ///
+    /// ```rust
+    /// use std::f32;
+    ///
+    /// use byteorder::{BigEndian, WriteBytesExt};
+    ///
+    /// let mut wtr = Vec::new();
+    /// wtr.write_f32::<BigEndian>(f32::consts::PI).unwrap();
+    /// assert_eq!(wtr, b"\x40\x49\x0f\xdb");
+    /// ```
+    #[inline]
+    fn write_f32<T: ByteOrder>(&mut self, n: f32) -> Result<()> {
+        let mut buf = [0; 4];
+        T::write_f32(&mut buf, n);
+        self.write_all(&buf)
+    }
+
+    /// Writes a IEEE754 double-precision (8 bytes) floating point number to
+    /// the underlying writer.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Write::write_all`].
+    ///
+    /// [`Write::write_all`]: https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all
+    ///
+    /// # Examples
+    ///
+    /// Write a big-endian double-precision floating point number to a `Write`:
+    ///
+    /// ```rust
+    /// use std::f64;
+    ///
+    /// use byteorder::{BigEndian, WriteBytesExt};
+    ///
+    /// let mut wtr = Vec::new();
+    /// wtr.write_f64::<BigEndian>(f64::consts::PI).unwrap();
+    /// assert_eq!(wtr, b"\x40\x09\x21\xfb\x54\x44\x2d\x18");
+    /// ```
+    #[inline]
+    fn write_f64<T: ByteOrder>(&mut self, n: f64) -> Result<()> {
+        let mut buf = [0; 8];
+        T::write_f64(&mut buf, n);
+        self.write_all(&buf)
+    }
+}
+
+/// All types that implement `Write` get methods defined in `WriteBytesExt`
+/// for free.
+impl<W: io::Write + ?Sized> WriteBytesExt for W {}
+
+/// Convert a slice of T (where T is plain old data) to its mutable binary
+/// representation.
+///
+/// This function is wildly unsafe because it permits arbitrary modification of
+/// the binary representation of any `Copy` type. Use with care. It's intended
+/// to be called only where `T` is a numeric type.
+unsafe fn slice_to_u8_mut<T: Copy>(slice: &mut [T]) -> &mut [u8] {
+    use core::mem::size_of;
+
+    let len = size_of::<T>() * slice.len();
+    slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut u8, len)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,23 +132,10 @@
 //! * structure!() macro takes a literal string as an argument.
 //! * It's called `structure` because `struct` is a reserved keyword in Rust.
 
-#[macro_use]
-extern crate proc_macro_hack;
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[doc(hidden)]
 pub extern crate byteorder;
 
-
-// Allow the "unused" #[macro_use] because there is a different un-ignorable
-// warning otherwise:
-//
-//    proc macro crates and `#[no_link]` crates have no effect without `#[macro_use]`
-#[allow(unused_imports)]
-#[macro_use]
-extern crate structure_macro_impl;
 #[doc(hidden)]
-pub use structure_macro_impl::*;
-
-proc_macro_expr_decl! {
-    structure! => structure_impl
-}
+pub use structure_macro_impl::structure;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,11 +133,6 @@
 //! * structure!() macro takes a literal string as an argument.
 //! * It's called `structure` because `struct` is a reserved keyword in Rust.
 
-
-#[doc(hidden)]
-#[cfg(not(feature = "std"))]
-pub use core2::io::{Cursor, Error, ErrorKind, Read, Result, Write};
-
 #[doc(hidden)]
 #[cfg(feature = "std")]
 pub use std::io::{Cursor, Error, ErrorKind, Read, Result, Write};
@@ -148,7 +143,19 @@ pub use byteorder::{WriteBytesExt, ReadBytesExt, BigEndian, LittleEndian};
 
 #[doc(hidden)]
 #[cfg(not(feature = "std"))]
-pub use byteorder::{BigEndian, LittleEndian};
+mod byteorder_ext;
+
+#[doc(hidden)]
+#[cfg(not(feature = "std"))]
+pub use core2::io::{Cursor, Error, ErrorKind, Read, Result, Write};
+
+#[doc(hidden)]
+#[cfg(not(feature = "std"))]
+pub use byteorder::{BigEndian, LittleEndian, ByteOrder};
+
+#[doc(hidden)]
+#[cfg(not(feature = "std"))]
+pub use byteorder_ext::{ReadBytesExt, WriteBytesExt};
 
 #[doc(hidden)]
 pub use structure_macro_impl::structure;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 //! Use format strings to create strongly-typed data pack/unpack interfaces (inspired by Python's `struct` library).
 //!
 //!
@@ -132,10 +133,14 @@
 //! * structure!() macro takes a literal string as an argument.
 //! * It's called `structure` because `struct` is a reserved keyword in Rust.
 
-#![cfg_attr(not(feature = "std"), no_std)]
 
 #[doc(hidden)]
-pub extern crate byteorder;
+#[cfg(not(feature = "std"))]
+pub use core2::io::{Cursor, Error, ErrorKind, Read, Result, Write};
+
+#[doc(hidden)]
+#[cfg(feature = "std")]
+pub use std::io::{Cursor, Error, ErrorKind, Read, Result, Write};
 
 #[doc(hidden)]
 pub use structure_macro_impl::structure;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,4 +143,12 @@ pub use core2::io::{Cursor, Error, ErrorKind, Read, Result, Write};
 pub use std::io::{Cursor, Error, ErrorKind, Read, Result, Write};
 
 #[doc(hidden)]
+#[cfg(feature = "std")]
+pub use byteorder::{WriteBytesExt, ReadBytesExt, BigEndian, LittleEndian};
+
+#[doc(hidden)]
+#[cfg(not(feature = "std"))]
+pub use byteorder::{BigEndian, LittleEndian};
+
+#[doc(hidden)]
 pub use structure_macro_impl::structure;

--- a/structure-macro-impl/Cargo.toml
+++ b/structure-macro-impl/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "structure-macro-impl"
+edition = "2018"
 version = "0.1.2" # remember to update the dependency in the root crate
 authors = ["Liran Ringel <liranringel@gmail.com>"]
 description = "Procedural macro crate for the structure crate."
@@ -11,5 +12,5 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE-APACHE", "LICENSE-
 proc-macro = true
 
 [dependencies]
-proc-macro-hack = "0.4"
-quote = "0.3"
+proc-macro2 = "1.0"
+quote = "1.0"

--- a/structure-macro-impl/src/lib.rs
+++ b/structure-macro-impl/src/lib.rs
@@ -1,65 +1,67 @@
 #![recursion_limit = "128"]
 
-#[macro_use]
-extern crate proc_macro_hack;
-#[macro_use]
-extern crate quote;
+extern crate proc_macro;
 
 use std::mem;
 use std::os::raw::c_void;
 use std::string::String;
-use quote::{Tokens, Ident};
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
 
-proc_macro_expr_impl! {
-    pub fn structure_impl(input: &str) -> String {
-        let format = trim_quotes(input);
-        let struct_name = Ident::from(format_to_struct_name(format));
-        let (values, endianness) = format_to_values(&format);
-        let (args, fn_decl_args, args_types) = build_args_list(&values);
-        let endianness = match endianness {
-            Endianness::Native => {
-                if cfg!(target_endian = "little") {
-                    quote!(LittleEndian)
-                } else {
-                    quote!(BigEndian)
-                }
+fn new_ident(s: &str) -> Ident {
+    Ident::new(s, Span::call_site())
+}
+
+#[proc_macro]
+pub fn structure(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let token_string = input.to_string();
+    let format = trim_quotes(&token_string);
+    let struct_name = new_ident(&format_to_struct_name(format));
+    let (values, endianness) = format_to_values(&format);
+    let (args, fn_decl_args, args_types) = build_args_list(&values);
+    let endianness = match endianness {
+        Endianness::Native => {
+            if cfg!(target_endian = "little") {
+                quote!(LittleEndian)
+            } else {
+                quote!(BigEndian)
             }
-            Endianness::LittleEndian => quote!(LittleEndian),
-            Endianness::BigEndian => quote!(BigEndian),
-        };
-        let size = calc_size(&values);
-        let pack_fn = build_pack_fn(&args, &fn_decl_args, size);
-        let pack_into_fn = build_pack_into_fn(&values, &fn_decl_args, &endianness);
-        let unpack_fn = build_unpack_fn(&args_types, size);
-        let unpack_from_fn = build_unpack_from_fn(&values, &args, &args_types, &endianness);
-        let size_fn = build_size_fn(size);
-        let output = quote! {{
-            #[derive(Debug)]
-            #[allow(non_camel_case_types)]
-            struct #struct_name;
-            #[allow(unused_imports)]
-            use std::io::{Result, Write, Read, Error, ErrorKind, Cursor};
-            #[allow(unused_imports)]
-            use std::os::raw::c_void;
-            #[allow(unused_imports)]
-            use structure::byteorder::{WriteBytesExt, ReadBytesExt, BigEndian, LittleEndian};
+        }
+        Endianness::LittleEndian => quote!(LittleEndian),
+        Endianness::BigEndian => quote!(BigEndian),
+    };
+    let size = calc_size(&values);
+    let pack_fn = build_pack_fn(&args, &fn_decl_args, size);
+    let pack_into_fn = build_pack_into_fn(&values, &fn_decl_args, &endianness);
+    let unpack_fn = build_unpack_fn(&args_types, size);
+    let unpack_from_fn = build_unpack_from_fn(&values, &args, &args_types, &endianness);
+    let size_fn = build_size_fn(size);
+    let output = quote! {{
+        #[derive(Debug)]
+        #[allow(non_camel_case_types)]
+        struct #struct_name;
+        #[allow(unused_imports)]
+        use std::io::{Result, Write, Read, Error, ErrorKind, Cursor};
+        #[allow(unused_imports)]
+        use std::os::raw::c_void;
+        #[allow(unused_imports)]
+        use structure::byteorder::{WriteBytesExt, ReadBytesExt, BigEndian, LittleEndian};
 
-            #[allow(unused)] static TRUE_BUF: &[u8] = &[1];
-            #[allow(unused)] static FALSE_BUF: &[u8] = &[0];
+        #[allow(unused)] static TRUE_BUF: &[u8] = &[1];
+        #[allow(unused)] static FALSE_BUF: &[u8] = &[0];
 
-            impl #struct_name {
-                #pack_fn
-                #pack_into_fn
-                #unpack_fn
-                #unpack_from_fn
-                #size_fn
-            }
+        impl #struct_name {
+            #pack_fn
+            #pack_into_fn
+            #unpack_fn
+            #unpack_from_fn
+            #size_fn
+        }
 
-            #struct_name // Create structure instance
-        }};
+        #struct_name // Create structure instance
+    }};
 
-        output.into_string()
-    }
+    output.into()
 }
 
 #[derive(PartialEq)]
@@ -69,7 +71,7 @@ enum Endianness {
     BigEndian,
 }
 
-fn build_pack_fn(args: &Tokens, fn_decl_args: &Tokens, size: usize) -> Tokens {
+fn build_pack_fn(args: &TokenStream, fn_decl_args: &TokenStream, size: usize) -> TokenStream {
     quote! {
         #[allow(unused)]
         fn pack(&self, #fn_decl_args) -> Result<Vec<u8>> {
@@ -80,37 +82,37 @@ fn build_pack_fn(args: &Tokens, fn_decl_args: &Tokens, size: usize) -> Tokens {
     }
 }
 
-fn build_pack_into_fn(values: &[StructValue], fn_decl_args: &Tokens, endianness: &Tokens) -> Tokens {
+fn build_pack_into_fn(values: &[StructValue], fn_decl_args: &TokenStream, endianness: &TokenStream) -> TokenStream {
     // Pack each argument
-    let mut writings = Tokens::new();
+    let mut writings = quote!();
     let mut arg_index = 0;
     for value in values {
         let writing = match *value.kind() {
             ValueKind::Number | ValueKind::Boolean | ValueKind::Pointer => {
-                let mut tokens = Tokens::new();
+                let mut tokens = quote!();
                 for _ in 0..value.repeat() {
                     arg_index += 1;
-                    let current_arg = Ident::from(format!("_{}", arg_index));
+                    let current_arg = new_ident(&format!("_{}", arg_index));
                     if *value.kind() == ValueKind::Number {
-                        let byteorder_fn = Ident::from(format!("write_{}", value.type_name()));
+                        let byteorder_fn = new_ident(&format!("write_{}", value.type_name()));
                         match value.type_name().as_str() {
                             "u8" | "i8" => {
-                                tokens.append(quote! {wtr.#byteorder_fn(#current_arg)?;});
+                                tokens.extend(quote! {wtr.#byteorder_fn(#current_arg)?;});
                             }
                             _ => {
-                                tokens.append(quote! {wtr.#byteorder_fn::<#endianness>(#current_arg)?;});
+                                tokens.extend(quote! {wtr.#byteorder_fn::<#endianness>(#current_arg)?;});
                             }
                         }
                     } else if *value.kind() == ValueKind::Boolean {
-                        tokens.append(quote! {
+                        tokens.extend(quote! {
                             let buf = if #current_arg { TRUE_BUF } else { FALSE_BUF };
                             wtr.write(buf)?;
                         });
                     } else {
                         let size = mem::size_of::<usize>();
-                        let integer_type = Ident::from(format!("u{}", size * 8));
-                        let byteorder_fn = Ident::from(format!("write_u{}", size * 8));
-                        tokens.append(quote! {
+                        let integer_type = new_ident(&format!("u{}", size * 8));
+                        let byteorder_fn = new_ident(&format!("write_u{}", size * 8));
+                        tokens.extend(quote! {
                             let v = #current_arg as #integer_type;
                             wtr.#byteorder_fn::<#endianness>(v)?;
                         });
@@ -120,7 +122,7 @@ fn build_pack_into_fn(values: &[StructValue], fn_decl_args: &Tokens, endianness:
             }
             ValueKind::Buffer | ValueKind::FixedBuffer => {
                 arg_index += 1;
-                let current_arg = Ident::from(format!("_{}", arg_index));
+                let current_arg = new_ident(&format!("_{}", arg_index));
                 let buffer_length = value.repeat();
                 let length_check = if *value.kind() == ValueKind::Buffer {
                     // If the type is `ValueKind::Buffer`, and the given buffer is smaller than the
@@ -138,7 +140,7 @@ fn build_pack_into_fn(values: &[StructValue], fn_decl_args: &Tokens, endianness:
                     wtr.write_all(#current_arg)?;
                 };
                 if *value.kind() == ValueKind::Buffer {
-                    tokens.append(quote! {
+                    tokens.extend(quote! {
                         if #current_arg.len() != #buffer_length {
                             wtr.write_all(&vec![0; (#buffer_length - #current_arg.len())])?;
                         }
@@ -153,7 +155,7 @@ fn build_pack_into_fn(values: &[StructValue], fn_decl_args: &Tokens, endianness:
                 }
             }
         };
-        writings.append(writing);
+        writings.extend(writing);
     }
 
     quote! {
@@ -165,7 +167,7 @@ fn build_pack_into_fn(values: &[StructValue], fn_decl_args: &Tokens, endianness:
     }
 }
 
-fn build_unpack_fn(args_types: &Tokens, size: usize) -> Tokens {
+fn build_unpack_fn(args_types: &TokenStream, size: usize) -> TokenStream {
     quote! {
         #[allow(unused)]
         fn unpack<T: AsRef<[u8]>>(&self, buf: T) -> Result<(#args_types,)> {
@@ -180,36 +182,36 @@ fn build_unpack_fn(args_types: &Tokens, size: usize) -> Tokens {
     }
 }
 
-fn build_unpack_from_fn(values: &[StructValue], args: &Tokens, args_types: &Tokens, endianness: &Tokens) -> Tokens {
-    let mut readings = Tokens::new();
+fn build_unpack_from_fn(values: &[StructValue], args: &TokenStream, args_types: &TokenStream, endianness: &TokenStream) -> TokenStream {
+    let mut readings = quote!();
     let mut arg_index = 0;
     for value in values {
         let reading = match *value.kind() {
             ValueKind::Number | ValueKind::Boolean | ValueKind::Pointer => {
-                let mut tokens = Tokens::new();
+                let mut tokens = quote!();
                 for _ in 0..value.repeat() {
                     arg_index += 1;
-                    let current_arg = Ident::from(format!("_{}", arg_index));
+                    let current_arg = new_ident(&format!("_{}", arg_index));
                     if *value.kind() == ValueKind::Number {
-                        let byteorder_fn = Ident::from(format!("read_{}", value.type_name()));
+                        let byteorder_fn = new_ident(&format!("read_{}", value.type_name()));
                         match value.type_name().as_str() {
                             "u8" | "i8" => {
-                                tokens.append(quote! { let #current_arg = rdr.#byteorder_fn()?;});
+                                tokens.extend(quote! { let #current_arg = rdr.#byteorder_fn()?;});
                             }
                             _ => {
-                                tokens.append(quote! { let #current_arg = rdr.#byteorder_fn::<#endianness>()?;});
+                                tokens.extend(quote! { let #current_arg = rdr.#byteorder_fn::<#endianness>()?;});
                             }
                         }
                     } else if *value.kind() == ValueKind::Boolean {
-                        tokens.append(quote! {
+                        tokens.extend(quote! {
                             let #current_arg = rdr.read_u8()?;
                             let #current_arg = #current_arg != 0; // 0 is false
                         });
                     } else {
-                        let pointer_type = Ident::from(value.type_name().as_str());
+                        let pointer_type: TokenStream = value.type_name().parse().unwrap();
                         let size = mem::size_of::<usize>();
-                        let byteorder_fn = Ident::from(format!("read_u{}", size * 8));
-                        tokens.append(quote! {
+                        let byteorder_fn = new_ident(&format!("read_u{}", size * 8));
+                        tokens.extend(quote! {
                             let #current_arg = {
                                 let v = rdr.#byteorder_fn::<#endianness>()?;
                                 v as #pointer_type
@@ -221,7 +223,7 @@ fn build_unpack_from_fn(values: &[StructValue], args: &Tokens, args_types: &Toke
             }
             ValueKind::Buffer | ValueKind::FixedBuffer => {
                 arg_index += 1;
-                let current_arg = Ident::from(format!("_{}", arg_index));
+                let current_arg = new_ident(&format!("_{}", arg_index));
                 let buffer_length = value.repeat();
                 quote! {
                     let mut #current_arg = vec![0; #buffer_length];
@@ -235,7 +237,7 @@ fn build_unpack_from_fn(values: &[StructValue], args: &Tokens, args_types: &Toke
                 }
             }
         };
-        readings.append(reading);
+        readings.extend(reading);
     }
 
     quote! {
@@ -244,11 +246,11 @@ fn build_unpack_from_fn(values: &[StructValue], args: &Tokens, args_types: &Toke
             #readings
             Ok((#args,))
         }
-    }
+    }.into()
 }
 
 /// Build the args list, the function declaration args list and the type list
-fn build_args_list(values: &[StructValue]) -> (Tokens, Tokens, Tokens) {
+fn build_args_list(values: &[StructValue]) -> (TokenStream, TokenStream, TokenStream) {
     let mut args = vec![];
     let mut fn_decl_args = vec![];
     let mut args_types = vec![];
@@ -258,30 +260,36 @@ fn build_args_list(values: &[StructValue]) -> (Tokens, Tokens, Tokens) {
             ValueKind::Padding => continue,
             ValueKind::Buffer | ValueKind::FixedBuffer => {
                 arg_index += 1;
-                args.push(Ident::from(format!("_{}", arg_index)));
-                fn_decl_args.push(Ident::from(format!("_{}: {}", arg_index, v.type_name())));
-                args_types.push(Ident::from("Vec<u8>".to_owned()));
+                let arg_name = new_ident(&format!("_{}", arg_index));
+                args.push(arg_name.clone());
+                let arg_type: TokenStream = v.type_name().parse().unwrap();
+                fn_decl_args.push(quote! { #arg_name: #arg_type });
+                args_types.push(quote! { Vec<u8> });
             }
             _ => {
                 for _ in 0..v.repeat() {
                     arg_index += 1;
-                    args.push(Ident::from(format!("_{}", arg_index)));
-                    fn_decl_args.push(Ident::from(format!("_{}: {}", arg_index, v.type_name())));
-                    args_types.push(Ident::from(v.type_name().as_str()));
+                    let arg_name = new_ident(&format!("_{}", arg_index));
+                    args.push(arg_name.clone());
+                    let arg_type: TokenStream = v.type_name().parse().unwrap();
+                    fn_decl_args.push(quote! { #arg_name: #arg_type });
+                    args_types.push(quote! { #arg_type });
                 }
             }
         }
     }
-    (quote!(#(#args),*), quote!(#(#fn_decl_args),*), quote!(#(#args_types),*))
+    (quote!(#(#args),*).into(),
+     quote!(#(#fn_decl_args),*).into(),
+     quote!(#(#args_types),*).into())
 }
 
-fn build_size_fn(size: usize) -> Tokens {
+fn build_size_fn(size: usize) -> TokenStream {
     quote! {
         #[allow(unused)]
         fn size(&self) -> usize {
             #size
         }
-    }
+    }.into()
 }
 
 fn calc_size(values: &[StructValue]) -> usize {

--- a/structure-macro-impl/src/lib.rs
+++ b/structure-macro-impl/src/lib.rs
@@ -296,7 +296,7 @@ fn calc_size(values: &[StructValue]) -> usize {
     let mut size = 0;
     for v in values {
         if v.type_name().starts_with("*") {
-            mem::size_of::<*const c_void>();
+            _ = mem::size_of::<*const c_void>();
         }
         let type_size = match v.type_name().as_str() {
             "i8" => mem::size_of::<i8>(),

--- a/structure-macro-impl/src/lib.rs
+++ b/structure-macro-impl/src/lib.rs
@@ -41,7 +41,6 @@ pub fn structure(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         #[allow(non_camel_case_types)]
         struct #struct_name;
         
-        #[allow(unused_imports)]
         use structure::{Result, Write, Read, Error, ErrorKind, Cursor};
         use core::ffi::c_void;
 

--- a/structure-macro-impl/src/lib.rs
+++ b/structure-macro-impl/src/lib.rs
@@ -43,8 +43,6 @@ pub fn structure(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         
         use structure::{Result, Write, Read, Error, ErrorKind, Cursor};
         use core::ffi::c_void;
-
-        #[cfg(feature = "std")]
         use structure::{WriteBytesExt, ReadBytesExt, BigEndian, LittleEndian};
 
         #[allow(unused)] static TRUE_BUF: &[u8] = &[1];

--- a/structure-macro-impl/src/lib.rs
+++ b/structure-macro-impl/src/lib.rs
@@ -45,8 +45,8 @@ pub fn structure(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         use structure::{Result, Write, Read, Error, ErrorKind, Cursor};
         use core::ffi::c_void;
 
-        #[allow(unused_imports)]
-        use structure::byteorder::{WriteBytesExt, ReadBytesExt, BigEndian, LittleEndian};
+        #[cfg(feature = "std")]
+        use structure::{WriteBytesExt, ReadBytesExt, BigEndian, LittleEndian};
 
         #[allow(unused)] static TRUE_BUF: &[u8] = &[1];
         #[allow(unused)] static FALSE_BUF: &[u8] = &[0];

--- a/structure-macro-impl/src/lib.rs
+++ b/structure-macro-impl/src/lib.rs
@@ -1,10 +1,13 @@
 #![recursion_limit = "128"]
 
 extern crate proc_macro;
+extern crate alloc;
 
-use std::mem;
-use std::os::raw::c_void;
-use std::string::String;
+use alloc::string::String;
+use core::mem;
+use core::ffi::c_void;
+
+#[allow(unused_imports)]
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 
@@ -40,10 +43,11 @@ pub fn structure(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         #[derive(Debug)]
         #[allow(non_camel_case_types)]
         struct #struct_name;
+        
         #[allow(unused_imports)]
-        use std::io::{Result, Write, Read, Error, ErrorKind, Cursor};
-        #[allow(unused_imports)]
-        use std::os::raw::c_void;
+        use structure::{Result, Write, Read, Error, ErrorKind, Cursor};
+        use core::ffi::c_void;
+
         #[allow(unused_imports)]
         use structure::byteorder::{WriteBytesExt, ReadBytesExt, BigEndian, LittleEndian};
 

--- a/structure-macro-impl/src/lib.rs
+++ b/structure-macro-impl/src/lib.rs
@@ -1,7 +1,5 @@
 #![recursion_limit = "128"]
 
-extern crate proc_macro;
-
 use std::string::String;
 use std::mem;
 use std::os::raw::c_void;

--- a/structure-macro-impl/src/lib.rs
+++ b/structure-macro-impl/src/lib.rs
@@ -1,11 +1,10 @@
 #![recursion_limit = "128"]
 
 extern crate proc_macro;
-extern crate alloc;
 
-use alloc::string::String;
-use core::mem;
-use core::ffi::c_void;
+use std::string::String;
+use std::mem;
+use std::os::raw::c_void;
 
 #[allow(unused_imports)]
 use proc_macro2::{Ident, Span, TokenStream};

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,11 +1,10 @@
-#[macro_use]
-extern crate structure;
+use structure::{structure, ErrorKind, Cursor};
+use core::ffi::c_void;
 
-use std::os::raw::c_void;
-use std::mem::transmute;
-use std::io::ErrorKind;
-use std::io::Cursor;
+#[allow(unused_imports)]
+use structure::byteorder::{WriteBytesExt, ReadBytesExt, BigEndian, LittleEndian};
 
+use core::mem::transmute;
 
 #[test]
 fn pack() {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,9 +1,6 @@
 use structure::{structure, ErrorKind, Cursor};
 use core::ffi::c_void;
 
-#[allow(unused_imports)]
-use structure::byteorder::{WriteBytesExt, ReadBytesExt, BigEndian, LittleEndian};
-
 use core::mem::transmute;
 
 #[test]


### PR DESCRIPTION
This is a draft PR that adds no_std support to the crate, thereby enabling embedded hardware to use the crate

It is a collaborative effort with @birkenfeld and @shymega (I), and so the discussion will be moved here.

I had made a grave error in originally opening a PR for this, in that I opened it here - https://github.com/Cosmo-CoDiOS/structure/pull/2 - a mistake on my part.

Hopefully, this can now be reviewed. 